### PR TITLE
Force N to be an integer when computing the lag T vector

### DIFF
--- a/dcf.py
+++ b/dcf.py
@@ -380,8 +380,7 @@ if OPTS.noplot:
         sys.exit()
 
     plt.figure(0)
-    #plt.errorbar(T, DCF, DCFERR, color='k', ls='-', capsize=0)
-    plt.plot(T,DCF,'o')
+    plt.errorbar(T, DCF, DCFERR, color='k', ls='-', capsize=0)
     plt.xlabel("Lag")
     plt.ylabel("Correlation Coefficient")
     plt.xlim(OPTS.lgl[0], OPTS.lgh[0])

--- a/dcf.py
+++ b/dcf.py
@@ -330,7 +330,6 @@ TS1, TS2 = get_timeseries(OPTS.infile1[0], OPTS.infile2[0], OPTS.verbose, \
 
 DT = OPTS.dt[0]
 N = np.around((OPTS.lgh[0] - OPTS.lgl[0]) / float(DT))
-N += 1 if not np.mod(N,2) else 0 # make it even for zero lag check
 
 T = np.linspace(OPTS.lgl[0]+(DT/2.0), OPTS.lgh[0]-(DT/2.0), int(N))
 

--- a/dcf.py
+++ b/dcf.py
@@ -330,7 +330,9 @@ TS1, TS2 = get_timeseries(OPTS.infile1[0], OPTS.infile2[0], OPTS.verbose, \
 
 DT = OPTS.dt[0]
 N = np.around((OPTS.lgh[0] - OPTS.lgl[0]) / float(DT))
-T = np.linspace(OPTS.lgl[0]+(DT/2.0), OPTS.lgh[0]-(DT/2.0), N)
+N += 1 if not np.mod(N,2) else 0 # make it even for zero lag check
+
+T = np.linspace(OPTS.lgl[0]+(DT/2.0), OPTS.lgh[0]-(DT/2.0), int(N))
 
 if OPTS.weight[0] == 'slot':
 
@@ -379,7 +381,8 @@ if OPTS.noplot:
         sys.exit()
 
     plt.figure(0)
-    plt.errorbar(T, DCF, DCFERR, color='k', ls='-', capsize=0)
+    #plt.errorbar(T, DCF, DCFERR, color='k', ls='-', capsize=0)
+    plt.plot(T,DCF,'o')
     plt.xlabel("Lag")
     plt.ylabel("Correlation Coefficient")
     plt.xlim(OPTS.lgl[0], OPTS.lgh[0])


### PR DESCRIPTION
Recent numpy will fail in the linspace command is the number of values is not an integer, it won't cast a float, so it must be forced in the code. This check just forces the cast to an integer value.